### PR TITLE
feature/provider-refresh-and-task-check-actions

### DIFF
--- a/actions/lib/providers.py
+++ b/actions/lib/providers.py
@@ -67,9 +67,5 @@ class Providers(base_action.BaseAction):
 
         result = client.collections.providers.action.refresh(*resources)
 
-        # return the data objects from each of the action results
-        results = []
-        for idx, res in enumerate(result):
-            results.append(result[idx]['_data'])
-
-        return results
+        # return the data objects from the action results
+        return self._data_from_entity_list(result)

--- a/tests/test_action_providers.py
+++ b/tests/test_action_providers.py
@@ -70,8 +70,9 @@ class TestActionProviders(ManageIQBaseActionTestCase):
                                              collection_name="providers",
                                              query_dict=action._get_providers_query())
 
+    @mock.patch("lib.providers.base_action.BaseAction._data_from_entity_list")
     @mock.patch("lib.providers.base_action.BaseAction._get_objects")
-    def test_refresh_all_providers(self, mock__get_objects):
+    def test_refresh_all_providers(self, mock__get_objects, mock__data_from_list):
         action = self.get_action_instance({})
         kwargs_dict = {'server': 'test.com',
                        'provider_id': None}
@@ -79,14 +80,14 @@ class TestActionProviders(ManageIQBaseActionTestCase):
                            'id': '123456'},
                           {'name': 'provider2.domain.tld',
                            'id': '654321'}]
-        refresh_result = [{'_data': 'test data 1'},
-                          {'_data': 'test data 2'}]
-        expected_result = ['test data 1', 'test data 2']
+        refresh_result = 'test result'
+        expected_result = 'test data'
 
         # mock
         mock__get_objects.return_value = test_providers
         mock_client = mock.MagicMock()
         mock_client.collections.providers.action.refresh.return_value = refresh_result
+        mock__data_from_list.return_value = expected_result
 
         # execute
         result = action.refresh(mock_client, kwargs_dict)
@@ -100,8 +101,11 @@ class TestActionProviders(ManageIQBaseActionTestCase):
         mock_client.collections.providers.action.refresh.assert_called_with(
             *test_providers)
 
+        mock__data_from_list.assert_called_with(refresh_result)
+
+    @mock.patch("lib.providers.base_action.BaseAction._data_from_entity_list")
     @mock.patch("lib.providers.base_action.BaseAction._get_objects")
-    def test_refresh_one_provider(self, mock__get_objects):
+    def test_refresh_one_provider(self, mock__get_objects, mock__data_from_list):
         action = self.get_action_instance({})
         kwargs_dict = {'server': 'test.com',
                        'provider_id': '654321'}
@@ -109,16 +113,18 @@ class TestActionProviders(ManageIQBaseActionTestCase):
                            'id': '123456'},
                           {'name': 'provider2.domain.tld',
                            'id': '654321'}]
-        refresh_result = [{'_data': 'test data 1'}]
-        expected_result = ['test data 1']
+        refresh_result = 'test result'
+        expected_result = 'test data'
 
         # mock
         mock__get_objects.return_value = test_providers
         mock_client = mock.MagicMock()
         mock_client.collections.providers.action.refresh.return_value = refresh_result
+        mock__data_from_list.return_value = expected_result
 
         # execute
         result = action.refresh(mock_client, kwargs_dict)
+
         # assert
         self.assertEquals(result, expected_result)
         mock__get_objects.assert_called_with(client=mock_client,
@@ -128,3 +134,5 @@ class TestActionProviders(ManageIQBaseActionTestCase):
         mock_client.collections.providers.action.refresh.assert_called_with(
             {'name': 'provider2.domain.tld',
              'id': '654321'})
+
+        mock__data_from_list.assert_called_with(refresh_result)


### PR DESCRIPTION
Used _data_from_entity_list function from base action instead of rewriting it in providers